### PR TITLE
Update LAB_AK_05_Lab1_Ex1_ATP_policies.md

### DIFF
--- a/Instructions/Labs/MS500T00/LAB_AK_05_Lab1_Ex1_ATP_policies.md
+++ b/Instructions/Labs/MS500T00/LAB_AK_05_Lab1_Ex1_ATP_policies.md
@@ -24,7 +24,7 @@ In this task, you will add the URL **http://tailspintoys.com** to the company-wi
 
 9. On the **Name your policy** pane, enter `All company users` in the **Name** field. Click **Next**.
 
-10. On the **Users and domains** pane, enter `All Company`in the **Users** field, select it from the list. Click **Next**.
+10. On the **Users and domains** pane, enter `All Company`in the **Group** field, select it from the list. Click **Next**.
 
 11. On the **Protection settings** pane, select the following options and click **Next**:
 


### PR DESCRIPTION
Using "All company" does not work in the "Users" field, due to a known issue with Microsoft, however entering creating the Safe Link Policy runs correctly when "All company" is used in the "Groups" field.

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-