### PR TITLE
Update LAB_AK_05_Lab1_Ex1_ATP_policies.md

### DIFF
--- a/Instructions/Labs/MS500T00/LAB_AK_05_Lab1_Ex1_ATP_policies.md
+++ b/Instructions/Labs/MS500T00/LAB_AK_05_Lab1_Ex1_ATP_policies.md
@@ -22,7 +22,7 @@ In this task, you will add the URL **http://tailspintoys.com** to the company-wi
 
 8. Select the **+ Create** to add a new recipient policy.
 
-9. On the **Name your policy** pane, enter `All company users` in the **Name** field. Click **Next**.
+9. On the **Name your policy** pane, enter a unique name to your lab session `Unique Name` in the **Name** field. Click **Next**.
 
 10. On the **Users and domains** pane, enter `All Company`in the **Group** field, select it from the list. Click **Next**.
 


### PR DESCRIPTION
Changed the unique name for the Safe links policy because the old name was causing an error

# Module: 05
## Lab/Demo: 01
### Exercise: 01

Fixes # .

Changes proposed in this pull request:

-Changed the unique name for the Safe links policy in task 1, step 9 because the old name (All company users) was causing an error.
-
-